### PR TITLE
lower the outline rectangle's z-order in "Collect"

### DIFF
--- a/urlApp/op/adl/URLDriver.adl
+++ b/urlApp/op/adl/URLDriver.adl
@@ -171,6 +171,18 @@ composite {
 	}
 	"composite name"=""
 	children {
+		rectangle {
+			object {
+				x=360
+				y=205
+				width=350
+				height=280
+			}
+			"basic attribute" {
+				clr=14
+				fill="outline"
+			}
+		}
 		composite {
 			object {
 				x=487
@@ -494,18 +506,6 @@ composite {
 					textix="Acquire"
 					align="horiz. right"
 				}
-			}
-		}
-		rectangle {
-			object {
-				x=360
-				y=205
-				width=350
-				height=280
-			}
-			"basic attribute" {
-				clr=14
-				fill="outline"
 			}
 		}
 		composite {


### PR DESCRIPTION
Otherwise in the autoconverted caqtdm ui panel, the rectangle stays on top of all other widgets and blocks the mouse inputs.